### PR TITLE
refactor: developer experience given transitive dependencies

### DIFF
--- a/source/events/issue_handler/actions/created/commands/go/index.ts
+++ b/source/events/issue_handler/actions/created/commands/go/index.ts
@@ -21,13 +21,13 @@ import { getPrInfo } from '@adaptly/services/github/pulls/getPrInfo';
 export const go = async (payload: IssueCommentEvent, installationId: number, octokit: Octokit) => {
     Logger.info('/adaptly go invoked', { repository: payload.repository.full_name, PR: `#${payload.issue.number}` });
 
-    postBreakingChangesLoading(payload, octokit);
+    await postBreakingChangesLoading(payload, octokit);
 
     await setupRepositoryLocally(payload, installationId, octokit);
 
     const updatedDependencies = await getPackagesDependenciesUpdated(payload, octokit);
     if (!updatedDependencies.length) {
-        await communicateNoDependencyUpdatesFound(payload, octokit);
+        await communicatePRLooksGood(payload, octokit);
         return;
     }
 
@@ -66,10 +66,10 @@ export async function deleteRepositoryLocally(payload: IssueCommentEvent): Promi
     await rimraf(path.dirname(destinationPath));
 }
 
-async function communicateNoDependencyUpdatesFound(payload: IssueCommentEvent, octokit: Octokit): Promise<void> {
-    Logger.info('Responding about no dependency updates found');
+async function communicatePRLooksGood(payload: IssueCommentEvent, octokit: Octokit): Promise<void> {
+    Logger.info('Responding that PR with no dependency updates looks good');
 
-    const message = `No dependency updates to check in this PR`;
+    const message = `:white_check_mark:&nbsp;&nbsp;This PR looks good!\n\n`;
 
     const loadingCommentId = await getBreakingChangesLoadingCommentId(payload, octokit);
 


### PR DESCRIPTION
Closes #29

## Test
In playground I opened a PR that only updates lock file, so there is no manifest changed.

<img width="1304" alt="Screenshot 2023-08-10 at 10 05 53" src="https://github.com/getadaptly/adaptly/assets/42170848/4dc6131a-ade2-4065-8460-0e6a34582523">

I ran adaptly and it told the PR looks good

<img width="1035" alt="Screenshot 2023-08-10 at 10 05 46" src="https://github.com/getadaptly/adaptly/assets/42170848/8034dea5-cf52-4cd7-a94b-7c979216da63">

