### PR TITLE
Extract the base sha from the latest common parent commit

### DIFF
--- a/source/services/github/pulls/getPrInfo.ts
+++ b/source/services/github/pulls/getPrInfo.ts
@@ -24,7 +24,11 @@ export async function getPrInfo(payload: IssueCommentEvent, octokit: Octokit): P
         const response = await octokit.request(`GET /repos/${repoFullName}/pulls/${prId}`);
         const prInfo: PrInfo = response.data;
 
-        Logger.info(`Fetched PR information`, { repository: repoFullName, PR: `#${prId}` });
+        const commitsResponse = await octokit.request(`GET /repos/${repoFullName}/pulls/${prId}/commits`);
+        const commits = commitsResponse.data;
+        prInfo.base.sha = commits[0].parents[0].sha;
+
+        Logger.info(`Fetched PR information`, { repository: repoFullName, PR: `#${prId}`, baseSHA: prInfo.base.sha });
 
         return prInfo;
     } catch (error) {


### PR DESCRIPTION
When I am reproducing the PRs, I checkout main (base) at the specific commit that the original PR was also based on, then cherry pick all commits from the original PR in this new branch and last create a PR to merge into the main of the forked repo.

This looks fine, and the git log of the new branch is clean, reflecting the same as the original PR.

BUT, the GitHub API, when you ask for information about the PR provides you with:

- base.sha
- head.sha

The base.sha unfortunately refers to the latest SHA in the base.ref (main) at the time of creation of the PR. So it does NOT point to the latest commit found in the head branch that is also in base (the one we checkout out from)

And so on Adaptly side we are picking up the wrong commit.

Note: this is fine for the original PRs but this logic does not work for the ones that we are reproducing.

The workaround I found that should work for both is to do the following:

```python
repo = g.get_repo(f"donutegg/strapi")
pr = repo.get_pull(1)

latest_commit = pr.get_commits().reversed[0]
base_commit_sha = latest_commit.parents[0].sha
print(base_commit_sha)
```

Basically instead of simply looking at `pr.base.sha`, we are going to look at the parent commit of the first commit in the PR, which is going to be the one where we checked out from.