### PR TITLE
fix issues

### DIFF
--- a/source/events/issue_handler/actions/created/commands/go/source/breaking-changes/report.ts
+++ b/source/events/issue_handler/actions/created/commands/go/source/breaking-changes/report.ts
@@ -55,6 +55,10 @@ async function getBreakingChangesMessage(dependencyUpdate: DependencyUpdate, bre
     if (breakingChanges.length) {
         const releaseUrl = await getReleaseUrl(dependencyUpdate.dependencyRepoUrl, dependencyUpdate.cursorVersion);
 
+        if (dependencyUpdate.dependencyName.startsWith('@types/')) {
+            return `:see_no_evil:&nbsp;&nbsp;Adaptly ignores Type updates.Types have no clear source of change logs so Adaptly does not check Type updates.\n\nPackage: [${dependencyUpdate.dependencyName}](${dependencyUpdate.dependencyUrl})\nVersion: [${dependencyUpdate.cursorVersion}](${releaseUrl})\n`;
+        }
+
         message = `:information_source:&nbsp;&nbsp;Breaking Changes in the Dependency's Changelog. Check breaking changes and run \`/adaptly go\` to continue checking next versions.\n\nPackage: [${dependencyUpdate.dependencyName}](${dependencyUpdate.dependencyUrl})\nVersion: [${dependencyUpdate.cursorVersion}](${releaseUrl})\n`;
 
         let breakingChangeNumber = 1;

--- a/source/services/adaptly/changelogHunter.ts
+++ b/source/services/adaptly/changelogHunter.ts
@@ -62,7 +62,13 @@ const getReleaseNotes = async (githubRepoUrl: string, accessToken: string, targe
 
     const response: AxiosResponse = await fetchReleaseNotes(releaseUrl, accessToken);
 
-    return response.data.body;
+    const releaseNotes = response.data.body;
+
+    if (!releaseNotes) {
+        return 'Nothing has been changed. Everything will work perfectly';
+    }
+
+    return releaseNotes;
 };
 
 const getReleaseNotesWithPrefix = async (githubRepoUrl: string, accessToken: string, targetVersion: string, prefix: string): Promise<string> => {
@@ -74,7 +80,13 @@ const getReleaseNotesWithPrefix = async (githubRepoUrl: string, accessToken: str
 
     const response: AxiosResponse = await fetchReleaseNotes(releaseUrl, accessToken);
 
-    return response.data.body;
+    const releaseNotes = response.data.body;
+
+    if (!releaseNotes) {
+        return 'Nothing has been changed. Everything will work perfectly';
+    }
+
+    return releaseNotes;
 };
 
 async function getChangelogMd(githubRepoUrl: string, targetVersion: string, octokit: Octokit): Promise<string> {

--- a/source/services/adaptly/dependencyParser/languages/typescript/packageJsonParser.ts
+++ b/source/services/adaptly/dependencyParser/languages/typescript/packageJsonParser.ts
@@ -45,7 +45,17 @@ export class PackageJsonParser implements DependenciesParser {
             const response: AxiosResponse = await axios.get(npmApiUrl);
 
             const packageInfo = response.data;
-            const repoUrl = packageInfo.repository.url;
+            const repository = packageInfo.repository;
+
+            let repoUrl = '';
+
+            if (repository) {
+                repoUrl = packageInfo.repository.url;
+            } else {
+                const maintainer = packageInfo.maintainers[0].name;
+                const repoName = `${maintainer}/${packageName}`;
+                repoUrl = `git+https://github.com/${repoName}.git`;
+            }
 
             if (!repoUrl) {
                 throw new Error('No repoUrl');


### PR DESCRIPTION
fix: prisma-fork:2 - github releases had "null" body. Return default string if no release notes exist for a release.

fix: prisma-fork:3 - could not find github repository via npm registry, because npm package is not linked to github. Instead i did best guess that works - get first maintainer name, and combine ${name}/${package} to get github repository url.

fix: prisma-fork:4 - adaptly ignoring types is now communicated more clearly:
<img width="1098" alt="Screenshot 2023-08-16 at 11 50 40" src="https://github.com/getadaptly/adaptly/assets/42170848/d25720ce-b272-419d-b2b5-75f403b69f70">
